### PR TITLE
add full width line separator

### DIFF
--- a/bin/menuconfig
+++ b/bin/menuconfig
@@ -35,9 +35,6 @@ C_MSG_INFO="$C_LGRN"
 C_MSG_TIPS="$C_LYEL"
 C_MSG_HR="$C_CYAN"
 
-MENU_HR="="
-MENU_HR_C="${C_MSG_HR}${MENU_HR}${C_NONE}"
-
 msg() {
     TYPE=$1
     shift
@@ -47,7 +44,7 @@ msg() {
         norm) printf "$C_MSG_NORM%s$C_NONE\n" "$*" >&2 ;;
         info) printf "$C_MSG_INFO%s$C_NONE\n" "$*" >&2 ;;
         tips) printf "$C_LYEL%s$C_NONE\n" "$*" >&2 ;;
-        hr)   printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' "$MENU_HR" ;; 
+        hr)   printf "$C_MSG_HR%s$C_NONE\n" "$*" >&2 ;;
         null) ;;
         *)    printf "%s\n" "$*" ;;
     esac
@@ -283,9 +280,10 @@ clear_variables_by_prefix() {
     done
 }
 
-menu_unset_variables() {
+menu_prepare_vars() {
     unset PROMPT MENU_INDEX
     clear_variables_by_prefix MENU_ITEM_
+    menu_set_hr_param
 }
 
 ask_yes() {
@@ -530,6 +528,13 @@ menu_is_active_item() {
     esac
 }
 
+# Set the thematic break (horizontal rule) in width of screen
+menu_set_hr_param() {
+    COLUMNS=$(tput cols)
+    MENU_HR="$(printf '%*s\n' "$COLUMNS" '' | tr ' ' =)"
+    MENU_HR_C="${C_MSG_HR}${MENU_HR}${C_NONE}"
+}
+
 menu_show_active_distributive() {
     msg hr $MENU_HR
     if [ ! -L $DISTRO_ACTIVE_LINK ]; then
@@ -707,7 +712,7 @@ menu_main() {
     CONTINUE_WRONG="eval { echo Wrong input; continue; }"
 
     clear
-    while menu_unset_variables
+    while menu_prepare_vars
           menu_show_active_distributive
           menu_show_prompt
           read ANS

--- a/bin/menuconfig
+++ b/bin/menuconfig
@@ -28,7 +28,7 @@ C_MSG_INFO="$C_LGRN"
 C_MSG_TIPS="$C_LYEL"
 C_MSG_HR="$C_CYAN"
 
-MENU_HR="==================================================================================="
+MENU_HR="="
 MENU_HR_C="${C_MSG_HR}${MENU_HR}${C_NONE}"
 
 msg() {
@@ -40,7 +40,7 @@ msg() {
         norm) printf "$C_MSG_NORM%s$C_NONE\n" "$*" >&2 ;;
         info) printf "$C_MSG_INFO%s$C_NONE\n" "$*" >&2 ;;
         tips) printf "$C_LYEL%s$C_NONE\n" "$*" >&2 ;;
-        hr)   printf "$C_MSG_HR%s$C_NONE\n" "$*" >&2 ;;
+        hr)   printf '%*s\n' "${COLUMNS:-$(tput cols)}" '' | tr ' ' "$MENU_HR" ;; 
         null) ;;
         *)    printf "%s\n" "$*" ;;
     esac


### PR DESCRIPTION
where `msg` is used the auto scaling is used. Not sure if the color is supported this way

[Source](https://wiki.bash-hackers.org/snipplets/print_horizontal_line#a_line_across_the_entire_width_of_the_terminal) of the full width trick. [Notion mirror](https://www.notion.so/antonpolishko/bash-printf-faae0d0e05384071a3b814e8f771d588)
